### PR TITLE
feat: schema for types.yaml

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "yaml.schemas": {
+        "types.json": "types.yaml"
+    }
+}

--- a/types.json
+++ b/types.json
@@ -1,0 +1,52 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "colors",
+    "description": "Colors for file categories\nhttps://github.com/karlding/dirchromatic",
+    "type": "array",
+    "minItems": 1,
+    "uniqueItems": true,
+    "items": {
+        "title": "color",
+        "description": "A color for file category\nhttps://github.com/karlding/dirchromatic",
+        "type": "object",
+        "properties": {
+            "colour": {
+                "title": "color",
+                "description": "A file category color\nhttps://github.com/karlding/dirchromatic",
+                "type": "string",
+                "pattern": "^0[01234];[39][0-8]$"
+            },
+            "description": {
+                "title": "description",
+                "description": "A file category description\nhttps://github.com/karlding/dirchromatic",
+                "type": "string",
+                "minLength": 1,
+                "pattern": "[^ ]",
+                "examples": [
+                    "archive files"
+                ]
+            },
+            "src": {
+                "title": "source",
+                "description": "File category extensions\nhttps://github.com/karlding/dirchromatic",
+                "type": "string",
+                "enum": [
+                    "types/archive.yaml",
+                    "types/audio.yaml",
+                    "types/binary.yaml",
+                    "types/build.yaml",
+                    "types/code.yaml",
+                    "types/config.yaml",
+                    "types/data.yaml",
+                    "types/doc.yaml",
+                    "types/image-raw.yaml",
+                    "types/image.yaml",
+                    "types/other.yaml",
+                    "types/video.yaml"
+                ]
+            }
+        },
+        "minProperties": 3,
+        "additionalProperties": false
+    }
+}


### PR DESCRIPTION
![image](https://github.com/karlding/dirchromatic/assets/42812113/3aa957e2-181d-46f9-8bd3-3f804fc0a1f2)
![image](https://github.com/karlding/dirchromatic/assets/42812113/2eb77fe8-36fc-4dfb-b045-98dbbee1528a)
![image](https://github.com/karlding/dirchromatic/assets/42812113/442ef803-bc14-418e-94d9-9f3354cdcf37)

BTW, according to [this](https://dev.to/ifenna__/adding-colors-to-bash-scripts-48g4) article, there is no such foreground color like 38. Please correct me if I am wrong.